### PR TITLE
Enhancement/tibco driver handling

### DIFF
--- a/driver/src/main/java/com/consol/citrus/db/driver/JdbcResultSet.java
+++ b/driver/src/main/java/com/consol/citrus/db/driver/JdbcResultSet.java
@@ -70,8 +70,12 @@ public class JdbcResultSet implements java.sql.ResultSet {
 
     @Override
     public boolean next() {
-        row = dataSet.getNextRow();
-        return row != null;
+        final Row nextRow = dataSet.getNextRow();
+        final boolean nextRowContainsData = nextRow != null;
+        if(nextRowContainsData){
+            this.row = nextRow;
+        }
+        return nextRowContainsData;
     }
 
     @Override

--- a/driver/src/main/java/com/consol/citrus/db/driver/dataset/DataSet.java
+++ b/driver/src/main/java/com/consol/citrus/db/driver/dataset/DataSet.java
@@ -45,12 +45,14 @@ public class DataSet {
 
     /**
      * Gets next row in this data set based on cursor position.
+     * If there is no further row, the index cursor position stays untouched
      * @return The next row of the dataset or null if no further row is available
      */
     @JsonIgnore
     public Row getNextRow(){
         final int index = cursor.getAndIncrement();
         if(rows.size() <= index){
+            cursor.set(cursor.get()-1);
             return null;
         }
 

--- a/driver/src/main/java/com/consol/citrus/db/driver/dataset/DataSet.java
+++ b/driver/src/main/java/com/consol/citrus/db/driver/dataset/DataSet.java
@@ -45,7 +45,7 @@ public class DataSet {
 
     /**
      * Gets next row in this data set based on cursor position.
-     * If there is no further row, the index cursor position stays untouched
+     * If there is no further row, the index cursor position stays untouched.
      * @return The next row of the dataset or null if no further row is available
      */
     @JsonIgnore

--- a/driver/src/test/java/com/consol/citrus/db/driver/JdbcResultSetTest.java
+++ b/driver/src/test/java/com/consol/citrus/db/driver/JdbcResultSetTest.java
@@ -791,6 +791,24 @@ public class JdbcResultSetTest {
     }
 
     @Test
+    public void testRowIsPreservedInCaseOfNoDataFromDataSet() {
+
+        //GIVEN
+        final String expectedString = "bar";
+        final JdbcResultSet resultSet = generateResultSet(expectedString);
+        resultSet.next();
+        resultSet.next();
+
+        //WHEN
+        final boolean nextRowContainsNewData = resultSet.next();
+
+        //THEN
+        final String string = resultSet.getString(TEST_VALUE_INDEX_JDBC);
+        assertEquals(string, expectedString);
+        assertFalse(nextRowContainsNewData);
+    }
+
+    @Test
     public void testToString(){
         ToStringVerifier.forClass(JdbcResultSet.class).verify();
     }

--- a/driver/src/test/java/com/consol/citrus/db/driver/dataset/DataSetTest.java
+++ b/driver/src/test/java/com/consol/citrus/db/driver/dataset/DataSetTest.java
@@ -28,22 +28,25 @@ public class DataSetTest {
     }
 
     @Test
-    public void testCursorPositionIsPreservationInCaseOfNoData(){
+    public void testCursorPositionIsPreservationInCaseOfNoMoreData(){
 
-        //WHEN
+        //GIVEN
+        final DataSet dataSet = createTestDataSet();
         dataSet.getNextRow();
 
+        //WHEN
+        final Row nextRow = dataSet.getNextRow();
+
         //THEN
-        assertEquals(dataSet.getCursor(), 0);
+        assertEquals(dataSet.getCursor(), 1);
+        assertNull(nextRow);
     }
 
     @Test
     public void testCursorPositionMovesInCaseOfMoreData(){
 
         //GIVEN
-        final Map<String, Object> testData = Collections.singletonMap("foo","bar");
-        final List<Row> testDataRows = Lists.newArrayList(new Row(testData));
-        final DataSet dataSet = new DataSet(testDataRows);
+        final DataSet dataSet = createTestDataSet();
 
         //WHEN
         dataSet.getNextRow();
@@ -63,5 +66,11 @@ public class DataSetTest {
                 .forClass(DataSet.class)
                 .withIgnoredFields("cursor")
                 .verify();
+    }
+
+    private DataSet createTestDataSet() {
+        final Map<String, Object> testData = Collections.singletonMap("foo", "bar");
+        final List<Row> testDataRows = Lists.newArrayList(new Row(testData));
+        return new DataSet(testDataRows);
     }
 }

--- a/driver/src/test/java/com/consol/citrus/db/driver/dataset/DataSetTest.java
+++ b/driver/src/test/java/com/consol/citrus/db/driver/dataset/DataSetTest.java
@@ -4,22 +4,52 @@ import com.consol.citrus.db.driver.data.Row;
 import com.jparams.verifier.tostring.ToStringVerifier;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 public class DataSetTest {
 
+    private final DataSet dataSet = new DataSet();
+
     @Test
     public void testEmptyDataSetReturnsNullOnGetNextRow() {
-
-        //GIVEN
-        final DataSet dataSet = new DataSet();
 
         //WHEN
         final Row nextRow = dataSet.getNextRow();
 
         //THEN
         assertNull(nextRow);
+    }
+
+    @Test
+    public void testCursorPositionIsPreservationInCaseOfNoData(){
+
+        //WHEN
+        dataSet.getNextRow();
+
+        //THEN
+        assertEquals(dataSet.getCursor(), 0);
+    }
+
+    @Test
+    public void testCursorPositionMovesInCaseOfMoreData(){
+
+        //GIVEN
+        final Map<String, Object> testData = Collections.singletonMap("foo","bar");
+        final List<Row> testDataRows = Lists.newArrayList(new Row(testData));
+        final DataSet dataSet = new DataSet(testDataRows);
+
+        //WHEN
+        dataSet.getNextRow();
+
+        //THEN
+        assertEquals(dataSet.getCursor(), 1);
     }
 
     @Test


### PR DESCRIPTION
This PR is concerning #29  and softens the JDBC driver contract so that TIBCO Systems are able to work with the driver without limitations.

The issue is caused by the fact that whenever the `next()` method is called on a `ResultSet` the pointer to the data moves one step forward. If the last row of the `ResultSet` has been reached and `next()` is called, the pointer to the data moves further and leaves the valid data section. From my knowledge, this is absolutely fine concerning the JDBC contract. Nevertheless, the TIBCO JDBC integration expects that Data is returned whenever the `ResultSet` is accessed. This PR changes the `ResultSet` and `DataSet` management, so that the pointer cannot leave the valid data section anymore. So no matter how often you call the `next()` method when the last row is reached, the data accessed through the `ResultSet` will stay at the last row.

BR,
Sven